### PR TITLE
fix: 修复剪贴板 katex 渲染问题

### DIFF
--- a/pastebin-33oj/templates/paste_show.html
+++ b/pastebin-33oj/templates/paste_show.html
@@ -15,7 +15,7 @@
                 {{ datetimeSpan(doc.updateAt) | safe }} </p>
           </div>
         </div>
-        <div class="section__body typo"
+        <div class="section__body typo richmedia"
           style="padding-left:20px;padding-right: 20px;padding-top: 30px;padding-bottom: 20px;">
           {{ doc.content|markdown|safe }}
         </div>


### PR DESCRIPTION
hydro 后端预渲染的 latex 公式块似乎有一个很小的长度限制，超出长度限制的公式会在前端渲染。

katex 只会渲染 class 包含 `richmedia` 的元素，而 paste_show.html 中并没有添加 `richmedia`。这会造成某些公式无法渲染的问题，例如下图：

![image](https://github.com/user-attachments/assets/05ad4810-1b7b-47df-a924-3f99278feceb)

图片对应的 markdown 如下：

```
$g^m\equiv g^{2m}\equiv \ldots \equiv $ $g^{km}\equiv g^{p-1}\equiv 1(mod\ p)$

$$

g ^ m \equiv g ^ {2m} \equiv . . . \equiv g ^ {km} \equiv g ^ {p-1} \equiv 1 \pmod {p}

$$

$g^m\equiv g^{2m}\equiv...\equiv g^{km}\equiv $  

$g^{km}\equiv g^{p-1}\equiv 1(mod\ p)$

$g^m\equiv g^{2m}\equiv...\equiv g^{km}\equiv g^{p-1}\equiv $  

$g^m\equiv g^{2m}\equiv$ 

---
```

能看到超出一定长度的公式块无法正常渲染。
